### PR TITLE
Should not end an async-writer passed in as out

### DIFF
--- a/lib/raptor-renderer.js
+++ b/lib/raptor-renderer.js
@@ -36,16 +36,19 @@ exports.render = function (renderer, input, out) {
 
     var actualOut = out;
     var actualData = input || {};
+    var shouldEnd = false;
 
     if (typeof callback === 'function') {
         // found a callback
         if (numArgs === 3) {
             actualOut = asyncWriter.create();
+            shouldEnd = true;
         }
     } else {
         callback = null;
         if (!actualOut) {
             actualOut = asyncWriter.create();
+            shouldEnd = true;
         }
     }
 
@@ -73,11 +76,11 @@ exports.render = function (renderer, input, out) {
                 callback(null, new RenderResult(actualOut.getOutput(), actualOut));
             })
             .on('error', callback);
-        actualOut.end();
+        if(shouldEnd) actualOut.end();
     } else {
         // NOTE: If no callback is provided then it is assumed that no asynchronous rendering occurred.
         //       Might want to add some checks in the future to ensure the actualOut is really done
-        actualOut.end();
+        if(shouldEnd) actualOut.end();
         return new RenderResult(actualOut.getOutput(), actualOut);
     }
 };


### PR DESCRIPTION
There is similar logic in the `render()` method in [marko-runtime.js#L164-L203](https://github.com/marko-js/marko/blob/dc706bceeaa9c942bed79af20a4d7fecd4d0db70/runtime/marko-runtime.js#L164-L203) that doesn't call `end()` if the `out` value that is passed in is already an `async-writer`.   

Without this change, everytime a widget that uses `createRenderFunc()` is rendered, the `async-writer` is being ended, and then continues to get written to.  This was masked by the fact that the previous implementation of `async-writer` allowed you to continue writing to the main writer once `end()` has been called.

As of `async-writer@1.4.4`, once `end()` is called the underlying writer is swapped out for a `voidWriter` to prevent additional writes, which makes this much more apparent.
